### PR TITLE
Ebuzz 98 signin back link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
     (_.———————————————————————————————————————————————————————————————————————————————._)
 
 
+## What is different in this fork of backbone?
+This fork of backbone is currently the same as backbone **1.1.2** (e.g. master = backbone tagged at **1.1.2**), but with router/history support for hashes for sections on the same page.  This does *not* include the code to navigate to the sections.
+
+
 Backbone supplies structure to JavaScript-heavy applications by providing models key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing application over a RESTful JSON interface.
 
 For Docs, License, Tests, pre-packed downloads, and everything else, really, see:

--- a/backbone.js
+++ b/backbone.js
@@ -1257,6 +1257,9 @@
 
         args[0] = args[0] ? args[0].replace(pathStripper, '') : null;
 
+        // somewhat hacky way of removing section hash from query params argument
+        args[1] = args[1] ? args[1].replace(pathStripper, '') : null;
+
         router.execute(callback, args);
         router.trigger.apply(router, ['route:' + name].concat(args));
         router.trigger('route', name, args);

--- a/backbone.js
+++ b/backbone.js
@@ -1254,6 +1254,9 @@
         var hashMatch = fragment.match(pathStripper);
         var hash = hashMatch? hashMatch[0].replace('#', '') : null;
         args.push(hash);
+
+        args[0] = args[0].replace(pathStripper, '');
+
         router.execute(callback, args);
         router.trigger.apply(router, ['route:' + name].concat(args));
         router.trigger('route', name, args);
@@ -1465,9 +1468,9 @@
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     checkUrl: function(e) {
-      var current = this.getFragment();
+      var current = this.getFragment().replace(pathStripper, '');
       if (current === this.fragment && this.iframe) {
-        current = this.getFragment(this.getHash(this.iframe));
+        current = this.getFragment(this.getHash(this.iframe)).replace(pathStripper, '');
       }
       if (current === this.fragment) return false;
       if (this.iframe) this.navigate(current);
@@ -1505,10 +1508,7 @@
 
       if (this.fragment === fragment) return;
       // Strip the hash for matching.
-      //fragment = fragment.replace(pathStripper, '');
-      this.fragment = fragment;
-
-
+      this.fragment = fragment.replace(pathStripper, '');
 
       // Don't include a trailing slash on the root.
       if (fragment === '' && url !== '/') url = url.slice(0, -1);

--- a/backbone.js
+++ b/backbone.js
@@ -1437,7 +1437,7 @@
 
         // If we've started off with a route from a `pushState`-enabled
         // browser, but we're currently in a browser that doesn't support it...
-        if (!this._hasPushState && !this.atRoot()) {
+        if (!this._hasPushState && (!this.atRoot() || this.location.search)) {
           this.fragment = this.getFragment(null, true);
           this.location.replace(this.root + '#' + this.fragment);
           // Return immediately as browser will do redirect to new url

--- a/backbone.js
+++ b/backbone.js
@@ -1254,10 +1254,10 @@
         var hashMatch = fragment.match(pathStripper);
         var hash = hashMatch? hashMatch[0].replace('#', '') : null;
 
-        // somewhat hacky way of removing section hash from route arguments
-        _.map(_.initial(args), function (arg) {
-          return arg ? arg.replace(pathStripper, '') : null;
-        });
+        // somewhat hacky way of removing section hash from last route arguments
+        var lastRouteIndex = args.length -2;
+        var lastRouteArg = args[lastRouteIndex];
+        args[lastRouteIndex] = lastRouteArg ? lastRouteArg.replace(pathStripper, '') : null;
 
         // somewhat hacky way of removing section hash from query params argument
         var queryParams = _.last(args);

--- a/backbone.js
+++ b/backbone.js
@@ -1255,6 +1255,7 @@
         var hash = hashMatch? hashMatch[0].replace('#', '') : null;
         args.push(hash);
 
+        // somewhat hacky way of removing section hash from route argument
         args[0] = args[0] ? args[0].replace(pathStripper, '') : null;
 
         // somewhat hacky way of removing section hash from query params argument

--- a/backbone.js
+++ b/backbone.js
@@ -1253,13 +1253,17 @@
         var args = router._extractParameters(route, fragment);
         var hashMatch = fragment.match(pathStripper);
         var hash = hashMatch? hashMatch[0].replace('#', '') : null;
-        args.push(hash);
 
-        // somewhat hacky way of removing section hash from route argument
-        args[0] = args[0] ? args[0].replace(pathStripper, '') : null;
+        // somewhat hacky way of removing section hash from route arguments
+        _.map(_.initial(args), function (arg) {
+          return arg ? arg.replace(pathStripper, '') : null;
+        });
 
         // somewhat hacky way of removing section hash from query params argument
-        args[1] = args[1] ? args[1].replace(pathStripper, '') : null;
+        var queryParams = _.last(args);
+        args[args.length -1] = queryParams ? queryParams.replace(pathStripper, '') : null;
+
+        args.push(hash);
 
         router.execute(callback, args);
         router.trigger.apply(router, ['route:' + name].concat(args));

--- a/backbone.js
+++ b/backbone.js
@@ -1468,13 +1468,19 @@
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     checkUrl: function(e) {
-      var current = this.getFragment().replace(pathStripper, '');
+      var current = this.getFragment();
+
       if (current === this.fragment && this.iframe) {
-        current = this.getFragment(this.getHash(this.iframe)).replace(pathStripper, '');
+        current = this.getFragment(this.getHash(this.iframe));
       }
+
+      var currentBase = current.replace(pathStripper, '');
+      var previousBase = this.fragment ? this.fragment.replace(pathStripper, '') : null;
+
       if (current === this.fragment) return false;
+
       if (this.iframe) this.navigate(current);
-      this.loadUrl();
+      if (currentBase !== previousBase) this.loadUrl();
     },
 
     // Attempt to load the current URL fragment. If a route succeeds with a
@@ -1504,11 +1510,10 @@
       var hashMatch = fragment.match(pathStripper);
       var hash = hashMatch ? hashMatch[0] : '';
       var url = this.root + (fragment = this.getFragment(fragment || ''));
-      var previousFragment = this.fragment.replace(pathStripper, '');
+      var previousFragment = this.fragment ? this.fragment.replace(pathStripper, '') : this.fragment;
 
       if (this.fragment === fragment) return;
-      // Strip the hash for matching.
-      this.fragment = fragment.replace(pathStripper, '');
+      this.fragment = fragment;
 
       // Don't include a trailing slash on the root.
       if (fragment === '' && url !== '/') url = url.slice(0, -1);

--- a/backbone.js
+++ b/backbone.js
@@ -1251,6 +1251,9 @@
       var router = this;
       Backbone.history.route(route, function(fragment) {
         var args = router._extractParameters(route, fragment);
+        var hashMatch = fragment.match(pathStripper);
+        var hash = hashMatch? hashMatch[0].replace('#', '') : null;
+        args.push(hash);
         router.execute(callback, args);
         router.trigger.apply(router, ['route:' + name].concat(args));
         router.trigger('route', name, args);
@@ -1370,7 +1373,7 @@
     getFragment: function(fragment, forcePushState) {
       if (fragment == null) {
         if (this._hasPushState || !this._wantsHashChange || forcePushState) {
-          fragment = decodeURI(this.location.pathname + this.location.search);
+          fragment = decodeURI(this.location.pathname + this.location.search + this.location.hash);
           var root = this.root.replace(trailingSlash, '');
           if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
         } else {
@@ -1495,13 +1498,17 @@
       if (!History.started) return false;
       if (!options || options === true) options = {trigger: !!options};
 
+      var hashMatch = fragment.match(pathStripper);
+      var hash = hashMatch ? hashMatch[0] : '';
       var url = this.root + (fragment = this.getFragment(fragment || ''));
-
-      // Strip the hash for matching.
-      fragment = fragment.replace(pathStripper, '');
+      var previousFragment = this.fragment.replace(pathStripper, '');
 
       if (this.fragment === fragment) return;
+      // Strip the hash for matching.
+      //fragment = fragment.replace(pathStripper, '');
       this.fragment = fragment;
+
+
 
       // Don't include a trailing slash on the root.
       if (fragment === '' && url !== '/') url = url.slice(0, -1);
@@ -1527,7 +1534,7 @@
       } else {
         return this.location.assign(url);
       }
-      if (options.trigger) return this.loadUrl(fragment);
+      if (options.trigger && previousFragment !== fragment) return this.loadUrl(fragment);
     },
 
     // Update the hash location, either replacing the current entry, or adding

--- a/backbone.js
+++ b/backbone.js
@@ -1255,7 +1255,7 @@
         var hash = hashMatch? hashMatch[0].replace('#', '') : null;
         args.push(hash);
 
-        args[0] = args[0].replace(pathStripper, '');
+        args[0] = args[0] ? args[0].replace(pathStripper, '') : null;
 
         router.execute(callback, args);
         router.trigger.apply(router, ['route:' + name].concat(args));

--- a/test/router.js
+++ b/test/router.js
@@ -378,13 +378,13 @@
     equal(router.charType, 'escaped');
   });
 
-  test("#1185 - Use pathname when hashChange is not wanted.", 1, function() {
+  test("#1185 - Include pathname when hashChange is not wanted.", 1, function() {
     Backbone.history.stop();
     location.replace('http://example.com/path/name#hash');
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({hashChange: false});
     var fragment = Backbone.history.getFragment();
-    strictEqual(fragment, location.pathname.replace(/^\//, ''));
+    strictEqual(fragment, location.pathname.replace(/^\//, '') + '#hash');
   });
 
   test("#1206 - Strip leading slash before location.assign.", 1, function() {
@@ -609,7 +609,7 @@
   test("#2062 - Trigger 'route' event on router instance.", 2, function() {
     router.on('route', function(name, args) {
       strictEqual(name, 'routeEvent');
-      deepEqual(args, ['x', null]);
+      deepEqual(args, ['x', null, null]);
     });
     location.replace('http://example.com#route-event/x');
     Backbone.history.checkUrl();

--- a/test/router.js
+++ b/test/router.js
@@ -447,13 +447,13 @@
 
   test("Normalize root.", 1, function() {
     Backbone.history.stop();
-    location.replace('http://example.com/root#fragment');
+    location.replace('http://example.com/root#fragment#hash');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url) {},
         replaceState: function(state, title, url) {
-          strictEqual(url, '/root/fragment');
+          strictEqual(url, '/root/fragment#hash');
         }
       }
     });
@@ -490,13 +490,13 @@
 
   test("Transition from hashChange to pushState.", 1, function() {
     Backbone.history.stop();
-    location.replace('http://example.com/root#x/y');
+    location.replace('http://example.com/root#x/y?a=b#hash');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(){},
         replaceState: function(state, title, url){
-          strictEqual(url, '/root/x/y');
+          strictEqual(url, '/root/x/y?a=b#hash');
         }
       }
     });
@@ -541,9 +541,9 @@
 
   test("Transition from pushState to hashChange.", 1, function() {
     Backbone.history.stop();
-    location.replace('http://example.com/root/x/y?a=b');
+    location.replace('http://example.com/root/x/y?a=b#hash');
     location.replace = function(url) {
-      strictEqual(url, '/root/#x/y?a=b');
+      strictEqual(url, '/root/#x/y?a=b#hash');
     };
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
@@ -752,8 +752,9 @@
     Backbone.history.start({pushState: true});
     var Router = Backbone.Router.extend({
       routes: {
-        path: function(params) {
+        path: function(params, hash) {
           strictEqual(params, 'x=y');
+          strictEqual(hash, 'hash');
         }
       }
     });
@@ -768,8 +769,9 @@
     Backbone.history.start({pushState: true});
     var Router = Backbone.Router.extend({
       routes: {
-        path: function(params) {
+        path: function(params, hash) {
           strictEqual(params, 'x=y');
+          strictEqual(hash, 'hash');
         }
       }
     });


### PR DESCRIPTION
Merge the changes to backbone history/router to support hash sections in the url.  This of course takes into account push-state vs non-push-state browsers and copy & pasting urls between them.  And don't forget the iframe hack for IE7.
